### PR TITLE
Improve import performance

### DIFF
--- a/NetworkedPlanet.Quince.Import/NetworkedPlanet.Quince.Import.csproj
+++ b/NetworkedPlanet.Quince.Import/NetworkedPlanet.Quince.Import.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NetworkedPlanet.Quince\NetworkedPlanet.Quince.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NetworkedPlanet.Quince.Import/Options.cs
+++ b/NetworkedPlanet.Quince.Import/Options.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NetworkedPlanet.Quince.Import
+{
+    internal class Options
+    {
+        public string RepoDirectory { get; set; }
+        public string ImportFile { get; set; }
+        public Uri GraphUri { get; set; }
+    }
+}

--- a/NetworkedPlanet.Quince.Import/OptionsParser.cs
+++ b/NetworkedPlanet.Quince.Import/OptionsParser.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.IO;
+
+namespace NetworkedPlanet.Quince.Import
+{
+    internal class OptionsParser
+    {
+        public Options Parse(string[] args)
+        {
+            if (args.Length != 3)
+            {
+                throw new ArgumentException("Unexpected number of arguments on the command line. Expected exactly 3 arguments.");
+            }
+
+            var opts = new Options {RepoDirectory = args[0], ImportFile = args[1]};
+            if (!File.Exists(opts.ImportFile))
+            {
+                throw new ArgumentException($"Could not find the file '{opts.ImportFile}' for import.");
+            }
+
+            if (!Uri.TryCreate(args[2], UriKind.Absolute, out var graphUri))
+            {
+                throw new ArgumentException("Graph URI must be a valid absolute URI");
+            }
+            opts.GraphUri = graphUri;
+
+            return opts;
+        }
+    }
+}

--- a/NetworkedPlanet.Quince.Import/Program.cs
+++ b/NetworkedPlanet.Quince.Import/Program.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using VDS.RDF;
+
+namespace NetworkedPlanet.Quince.Import
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            Options options;
+            try
+            {
+                var parser = new OptionsParser();
+                options = parser.Parse(args);
+            }
+            catch (ArgumentException ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return -1;
+            }
+
+            EnsureRepository(options.RepoDirectory);
+            var repo = new DynamicFileStore(options.RepoDirectory, 1000);
+            var graph = new Graph {BaseUri = options.GraphUri};
+            graph.LoadFromFile(options.ImportFile);
+            var sw = Stopwatch.StartNew();
+            repo.Assert(graph);
+            repo.Flush();
+            sw.Stop();
+            Console.WriteLine($"Imported {graph.Triples.Count} triples in {sw.ElapsedMilliseconds} ms");
+            return 0;
+        }
+
+        private static void EnsureRepository(string repoDir)
+        {
+            if (!Directory.Exists(repoDir))
+            {
+                Directory.CreateDirectory(repoDir);
+            }
+        }
+    }
+}

--- a/NetworkedPlanet.Quince/DynamicFileStore.cs
+++ b/NetworkedPlanet.Quince/DynamicFileStore.cs
@@ -220,13 +220,6 @@ namespace NetworkedPlanet.Quince
             var ix = lines.BinarySearch(line);
             if (ix >= 0) return false;
             lines.Insert(~ix, line);
-            if (lines.Count > _splitThreshold)
-            {
-                if (CanSplit(lines, segment))
-                {
-                    SplitFile(storePath, lines, segment);
-                }
-            }
             return true;
         }
 
@@ -526,6 +519,22 @@ namespace NetworkedPlanet.Quince
             var cacheCount = cache.Count;
             var timer = new Stopwatch();
             timer.Start();
+
+            var toFlush = cache.Keys.ToList();
+            foreach (var fileName in toFlush)
+            {
+                var lines = cache[fileName];
+                if (lines.Count > _splitThreshold)
+                {
+                    var segment = fileName.StartsWith("_s") ? TripleSegment.Subject :
+                        fileName.StartsWith("_p") ? TripleSegment.Predicate : TripleSegment.Object;
+                    if (CanSplit(lines, segment))
+                    {
+                        SplitFile(fileName, lines, segment);
+                    }
+                }
+            }
+
             foreach (var pair in cache)
             {
                 var targetPath = Path.Combine(_baseDirectory.FullName, pair.Key);
@@ -547,23 +556,24 @@ namespace NetworkedPlanet.Quince
             Log.LogDebug("FlushCache: {0} entries written in {1} seconds", cacheCount, timer.Elapsed.TotalSeconds);
         }
 
-        private Regex SplitRegex = new Regex("(?<s>(_:[^\\s]+)|(<[^>]+>))\\s+(?<p>(_:[^\\s]+)|(<[^>]+>))\\s+(?<o>(_:[^\\s]+)|(<[^>]+>)|\"[^\"]*\"(@\\S+)?(\\^\\^<[^>]+>)?)\\s+(?<g>(_:[^\\s]+)|(<[^>]+>))\\s*\\.");
 
         private bool CanSplit(IReadOnlyList<string> lines, TripleSegment segment)
         {
-            if (lines.Count < _splitThreshold) return false;
-            //return CanSplitParser(lines, segment);
-            return CanSplitRegex(lines, segment);
+            return lines.Count >= _splitThreshold && CanSplitParser(lines, segment);
+            //return CanSplitRegex(lines, segment);
         }
+
+        // KA - Regex-based checking is slightly faster than using the DNR parser, but the parser is less likely to be wrong :-)
+        /*
+        private Regex SplitRegex = new Regex("(?<s>(_:[^\\s]+)|(<[^>]+>))\\s+(?<p>(_:[^\\s]+)|(<[^>]+>))\\s+(?<o>(_:[^\\s]+)|(<[^>]+>)|\"[^\"]*\"(@\\S+)?(\\^\\^<[^>]+>)?)\\s+(?<g>(_:[^\\s]+)|(<[^>]+>))\\s*\\.");
 
         private bool CanSplitRegex(IReadOnlyList<string> lines, TripleSegment segment)
         {
             var segmentGroup = segment == TripleSegment.Subject ? "s" : segment == TripleSegment.Predicate ? "p" : "o";
             var firstNode = SplitRegex.Match(lines[0]).Groups[segmentGroup].Value;
             return lines.Skip(1).Any(l => SplitRegex.Match(l).Groups[segmentGroup].Value != firstNode);
-
-            //return lines.Any(l => SplitRegex.Match(l).Groups[segmentGroup].Value != firstNode);
         }
+        */
 
         private bool CanSplitParser(IReadOnlyList<string> lines, TripleSegment segment)
         {

--- a/NetworkedPlanet.Quince/DynamicFileStore.cs
+++ b/NetworkedPlanet.Quince/DynamicFileStore.cs
@@ -62,8 +62,17 @@ namespace NetworkedPlanet.Quince
                 var objectPath = GetFilePath(objectFileName);
                 Assert(TripleSegment.Object, lineStr, objectPath);
                 var predicateFileName = GetPredicateFileName(predicate);
-                var preidcatePath = GetFilePath(predicateFileName);
-                Assert(TripleSegment.Predicate, lineStr, preidcatePath);
+                var predicatePath = GetFilePath(predicateFileName);
+                Assert(TripleSegment.Predicate, lineStr, predicatePath);
+            }
+        }
+
+        public void Assert(IGraph graph)
+        {
+            Log.LogTrace($"AssertGraph: {graph.BaseUri}");
+            foreach (var t in graph.Triples)
+            {
+                Assert(t.Subject, t.Predicate, t.Object, graph.BaseUri);
             }
         }
 

--- a/NetworkedPlanet.Quince/IQuinceStore.cs
+++ b/NetworkedPlanet.Quince/IQuinceStore.cs
@@ -27,6 +27,12 @@ namespace NetworkedPlanet.Quince
         void Retract(INode subject, INode predicate, INode obj, Uri graph);
 
         /// <summary>
+        /// Add all the quads in the specified graph to the store
+        /// </summary>
+        /// <param name="graph">The graph to be added to the store</param>
+        void Assert(IGraph graph);
+
+        /// <summary>
         /// Retracts all of the triples in the specified graph
         /// </summary>
         /// <param name="graph">The graph to be dropped</param>

--- a/quince.sln
+++ b/quince.sln
@@ -3,11 +3,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.12
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkedPlanet.Quince", "NetworkedPlanet.Quince\NetworkedPlanet.Quince.csproj", "{12477E16-B8BE-49A0-9B5B-198D605C9D92}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetworkedPlanet.Quince", "NetworkedPlanet.Quince\NetworkedPlanet.Quince.csproj", "{12477E16-B8BE-49A0-9B5B-198D605C9D92}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkedPlanet.Quince.Tests", "NetworkedPlanet.Quince.Tests\NetworkedPlanet.Quince.Tests.csproj", "{721C7C3C-51C6-4E8B-95A3-B412A7CF9B7F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetworkedPlanet.Quince.Tests", "NetworkedPlanet.Quince.Tests\NetworkedPlanet.Quince.Tests.csproj", "{721C7C3C-51C6-4E8B-95A3-B412A7CF9B7F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkedPlanet.Quince.Import", "NetworkedPlanet.Quince.Import\NetworkedPlanet.Quince.Import.csproj", "{165D9788-5AA7-4577-BFFB-510A3CCE910A}"
 EndProject
 Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -21,8 +26,15 @@ Global
 		{721C7C3C-51C6-4E8B-95A3-B412A7CF9B7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{721C7C3C-51C6-4E8B-95A3-B412A7CF9B7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{721C7C3C-51C6-4E8B-95A3-B412A7CF9B7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{165D9788-5AA7-4577-BFFB-510A3CCE910A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{165D9788-5AA7-4577-BFFB-510A3CCE910A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{165D9788-5AA7-4577-BFFB-510A3CCE910A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{165D9788-5AA7-4577-BFFB-510A3CCE910A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1469E5DA-6440-4933-AEF2-14421151C1AD}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
* Added a really simple command line for importing a graph into a store to test and analyze import performance
* Added support to the IQuinceStore interface for importing a graph directly rather than having to assert individual triples
* Moved the test for file splits in DynamicFileStore from the triple Assert method to the FlushCache method. This massively (almost 2 orders of magnitude!) improves performance by avoiding a lot of unecessary file split checks.