### PR TITLE
Feature/add object enumeration

### DIFF
--- a/NetworkedPlanet.Quince.Tests/DynamicFileStoreSpec.cs
+++ b/NetworkedPlanet.Quince.Tests/DynamicFileStoreSpec.cs
@@ -158,6 +158,40 @@ namespace NetworkedPlanet.Quince.Tests
                 testHandler.TotalObjectStatements.Should().Be(2);
             }
         }
+
+        [Fact]
+        public void CanEnumerateObjectStatements()
+        {
+            using (var repoFixture = new RepositoryFixture("test-enumerate"))
+            {
+                repoFixture.Import("data\\test3.nq");
+                var testHandler = new TestResourceStatementHandler((objectNode, subjectStatements, objectStatements) =>
+                    {
+                        subjectStatements.All(x => x.Subject.Equals(objectNode)).Should().BeTrue();
+                        objectStatements.All(x => x.Object.Equals(objectNode)).Should().BeTrue();
+                    });
+                repoFixture.Store.EnumerateObjects(testHandler);
+                testHandler.TotalSubjects.Should().Be(2);
+                testHandler.TotalSubjectStatements.Should().Be(5);
+                testHandler.TotalObjectStatements.Should().Be(7);
+            }
+        }
+
+        [Fact]
+        public void CanEnumerateObjectsSmall()
+        {
+            using (var repoFixture = new RepositoryFixture("test-enumerate"))
+            {
+                repoFixture.Import("data\\test2.nq");
+                var testHandler = new TestTripleCollectionHandler(tc =>
+                {
+                    tc.Count.Should().Be(5);
+                    tc.All(x => x.Object.Equals(tc[0].Object)).Should().BeTrue();
+                });
+                repoFixture.Store.EnumerateSubjects(testHandler);
+                testHandler.TotalCount.Should().Be(1);
+            }
+        }
     }
 
     public class TestTripleCollectionHandler : ITripleCollectionHandler

--- a/NetworkedPlanet.Quince/IQuinceStore.cs
+++ b/NetworkedPlanet.Quince/IQuinceStore.cs
@@ -86,5 +86,18 @@ namespace NetworkedPlanet.Quince
         /// </summary>
         /// <param name="handler">A handler that will receive the resource node, the collection of statements with that resource as subject and the collection of statements with that resource as object</param>
         void EnumerateSubjects(IResourceStatementHandler handler);
+
+        /// <summary>
+        /// Get all triples in the repository with a non-literal object,
+        /// grouping triples by common object
+        /// </summary>
+        /// <param name="handler">A handler that will receive the collection of statements with a specific non-literal resource as object</param>
+        void EnumerateObjects(ITripleCollectionHandler handler);
+
+        /// <summary>
+        /// Enumerate all non-literal objects in the repository
+        /// </summary>
+        /// <param name="handler">A handler that will receive the object resource node, the collection of statements with that resource as subject and the collection of statements with that resource as object</param>
+        void EnumerateObjects(IResourceStatementHandler handler);
     }
 }

--- a/NetworkedPlanet.Quince/IQuinceStore.cs
+++ b/NetworkedPlanet.Quince/IQuinceStore.cs
@@ -88,16 +88,15 @@ namespace NetworkedPlanet.Quince
         void EnumerateSubjects(IResourceStatementHandler handler);
 
         /// <summary>
-        /// Get all triples in the repository with a non-literal object,
-        /// grouping triples by common object
+        /// Enumerate all object nodes in the repository
         /// </summary>
-        /// <param name="handler">A handler that will receive the collection of statements with a specific non-literal resource as object</param>
+        /// <param name="handler">A handler invoked for each unique object node, that will receive the object node itself and the collection of statements with that node as object</param>
         void EnumerateObjects(ITripleCollectionHandler handler);
 
         /// <summary>
-        /// Enumerate all non-literal objects in the repository
+        /// Enumerate all object nodes in the repository
         /// </summary>
-        /// <param name="handler">A handler that will receive the object resource node, the collection of statements with that resource as subject and the collection of statements with that resource as object</param>
+        /// <param name="handler">A handler that will receive the object node, the collection of statements with that node as subject and the collection of statements with that node as object</param>
         void EnumerateObjects(IResourceStatementHandler handler);
     }
 }

--- a/NetworkedPlanet.Quince/NetworkedPlanet.Quince.csproj
+++ b/NetworkedPlanet.Quince/NetworkedPlanet.Quince.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="dotNetRDF" Version="2.1.0" />
+    <PackageReference Include="dotNetRDF" Version="2.4.0" />
     <PackageReference Include="MedallionShell" Version="1.5.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Adds methods to enumerate the triples of the store grouped by object node. As with the EnumerateSubjects methods there are two variants, one which reports only the triples with the node in the object position; and one which reports the triples where the node appears in the subject position and the triples where the node appears in the object position.

This implementation enumerates all of the object nodes in the store using the objects index. It will invoke the callbacks for all types of object node (literals, blank nodes and URI nodes), though in the case of literal nodes there would never be any triples where the node appears in the subject position.