### PR TITLE
Fix for enumeration of triples by object

### DIFF
--- a/NetworkedPlanet.Quince.Tests/DynamicFileStoreSpec.cs
+++ b/NetworkedPlanet.Quince.Tests/DynamicFileStoreSpec.cs
@@ -192,6 +192,31 @@ namespace NetworkedPlanet.Quince.Tests
                 testHandler.TotalCount.Should().Be(1);
             }
         }
+
+        [Fact]
+        public void CanEnumerateSharedObjects()
+        {
+            using (var repoFixture = new RepositoryFixture("test-enumerate"))
+            {
+                repoFixture.Import("data\\test2a.nq");
+                var testHandler = new TestTripleCollectionHandler(tc =>
+                {
+                    tc.All(x=>x.Object.Equals(tc[0].Object)).Should().BeTrue();
+                    var objectUri = (tc[0].Object as IUriNode)?.Uri?.ToString();
+                    objectUri.Should().NotBeNull();
+                    if (objectUri.Equals("http://example.org/o/0"))
+                    {
+                        tc.Count.Should().Be(3);
+                    }
+                    if (objectUri.Equals("http://example.org/o/1"))
+                    {
+                        tc.Count.Should().Be(2);
+                    }
+                });
+                repoFixture.Store.EnumerateObjects(testHandler);
+                testHandler.TotalCount.Should().Be(2);
+            }
+        }
     }
 
     public class TestTripleCollectionHandler : ITripleCollectionHandler

--- a/NetworkedPlanet.Quince.Tests/NetworkedPlanet.Quince.Tests.csproj
+++ b/NetworkedPlanet.Quince.Tests/NetworkedPlanet.Quince.Tests.csproj
@@ -26,6 +26,9 @@
     <None Update="data\test2.nq">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="data\test2a.nq">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="data\test3.nq">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/NetworkedPlanet.Quince.Tests/data/test2a.nq
+++ b/NetworkedPlanet.Quince.Tests/data/test2a.nq
@@ -1,0 +1,5 @@
+<http://example.org/s/0> <http://example.org/p/0> <http://example.org/o/0> <http://example.org/g/1>.
+<http://example.org/s/0> <http://example.org/p/1> <http://example.org/o/1> <http://example.org/g/1>.
+<http://example.org/s/1> <http://example.org/p/0> <http://example.org/o/0> <http://example.org/g/1>.
+<http://example.org/s/1> <http://example.org/p/1> <http://example.org/o/1> <http://example.org/g/1>.
+<http://example.org/s/2> <http://example.org/p/0> <http://example.org/o/0> <http://example.org/g/1>.


### PR DESCRIPTION
The code had assumed that triples are in object node order in the NQuads file, but in fact they are in line sort order. This means that when enumerating by object, the entire NQuads file has to be scanned rather than being able to terminate the scan when a new object value is seen.